### PR TITLE
Domain: Fix Line's mappings and Waypoint's Order conflict

### DIFF
--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/TransportType.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/TransportType.java
@@ -12,7 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes;
+package eu.socialedge.hermes.domain;
 
 public enum TransportType {
     BUS, TROLLEY, TRAM, TRAIN;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/line/Line.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/line/Line.java
@@ -12,10 +12,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.line;
+package eu.socialedge.hermes.domain.line;
 
-import eu.socialedge.hermes.route.Route;
-import eu.socialedge.hermes.TransportType;
+import eu.socialedge.hermes.domain.TransportType;
+import eu.socialedge.hermes.domain.route.Route;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -46,7 +46,7 @@ public class Line implements Serializable {
     @Column(name = "type")
     private TransportType transportType;
 
-    @OneToMany(mappedBy = "route")
+    @OneToMany(mappedBy = "line")
     private Set<Route> routes;
 
     Line() {}

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/line/Operator.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/line/Operator.java
@@ -12,7 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.line;
+package eu.socialedge.hermes.domain.line;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Route.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Route.java
@@ -12,9 +12,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.route;
+package eu.socialedge.hermes.domain.route;
 
-import eu.socialedge.hermes.line.Line;
+import eu.socialedge.hermes.domain.line.Line;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Station.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Station.java
@@ -12,9 +12,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.route;
+package eu.socialedge.hermes.domain.route;
 
-import eu.socialedge.hermes.TransportType;
+import eu.socialedge.hermes.domain.TransportType;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Waypoint.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/route/Waypoint.java
@@ -12,7 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.route;
+package eu.socialedge.hermes.domain.route;
 
 import javax.persistence.*;
 import javax.validation.constraints.Min;
@@ -39,6 +39,7 @@ public class Waypoint implements Serializable, Comparable<Waypoint> {
     private Station station;
 
     @Min(1)
+    @Column(name = "position")
     private int order;
 
     Waypoint() {}

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Departure.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Departure.java
@@ -12,9 +12,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.schedule;
+package eu.socialedge.hermes.domain.schedule;
 
-import eu.socialedge.hermes.route.Waypoint;
+import eu.socialedge.hermes.domain.route.Waypoint;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Schedule.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Schedule.java
@@ -12,7 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.schedule;
+package eu.socialedge.hermes.domain.schedule;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Timetable.java
+++ b/hermes-domain/src/main/java/eu/socialedge/hermes/domain/schedule/Timetable.java
@@ -12,9 +12,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-package eu.socialedge.hermes.schedule;
+package eu.socialedge.hermes.domain.schedule;
 
-import eu.socialedge.hermes.route.Route;
+import eu.socialedge.hermes.domain.route.Route;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/LineRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/LineRepository.java
@@ -14,7 +14,7 @@
  */
 package eu.socialedge.hermes.repository.line;
 
-import eu.socialedge.hermes.line.Line;
+import eu.socialedge.hermes.domain.line.Line;
 import eu.socialedge.hermes.repository.Repository;
 
 public interface LineRepository extends Repository<Integer, Line> {

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/OperatorRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/OperatorRepository.java
@@ -14,7 +14,7 @@
  */
 package eu.socialedge.hermes.repository.line;
 
-import eu.socialedge.hermes.line.Operator;
+import eu.socialedge.hermes.domain.line.Operator;
 import eu.socialedge.hermes.repository.Repository;
 
 public interface OperatorRepository extends Repository<Integer, Operator> {

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/SpringJpaLineRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/SpringJpaLineRepository.java
@@ -14,7 +14,7 @@
  */
 package eu.socialedge.hermes.repository.line;
 
-import eu.socialedge.hermes.line.Line;
+import eu.socialedge.hermes.domain.line.Line;
 import eu.socialedge.hermes.repository.SpringJpaRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/SpringJpaOperatorRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/line/SpringJpaOperatorRepository.java
@@ -14,7 +14,7 @@
  */
 package eu.socialedge.hermes.repository.line;
 
-import eu.socialedge.hermes.line.Operator;
+import eu.socialedge.hermes.domain.line.Operator;
 import eu.socialedge.hermes.repository.SpringJpaRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/RouteRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/RouteRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.route;
 
 import eu.socialedge.hermes.repository.Repository;
-import eu.socialedge.hermes.route.Route;
+import eu.socialedge.hermes.domain.route.Route;
 
 public interface RouteRepository extends Repository<Integer, Route> {
 }

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/SpringJpaRouteRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/SpringJpaRouteRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.route;
 
 import eu.socialedge.hermes.repository.SpringJpaRepository;
-import eu.socialedge.hermes.route.Route;
+import eu.socialedge.hermes.domain.route.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/SpringJpaStationRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/SpringJpaStationRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.route;
 
 import eu.socialedge.hermes.repository.SpringJpaRepository;
-import eu.socialedge.hermes.route.Station;
+import eu.socialedge.hermes.domain.route.Station;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/StationRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/route/StationRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.route;
 
 import eu.socialedge.hermes.repository.Repository;
-import eu.socialedge.hermes.route.Station;
+import eu.socialedge.hermes.domain.route.Station;
 
 public interface StationRepository extends Repository<Integer, Station> {
 }

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/ScheduleRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/ScheduleRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.schedule;
 
 import eu.socialedge.hermes.repository.Repository;
-import eu.socialedge.hermes.schedule.Schedule;
+import eu.socialedge.hermes.domain.schedule.Schedule;
 
 public interface ScheduleRepository extends Repository<Integer, Schedule> {
 }

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/SpringJpaScheduleRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/SpringJpaScheduleRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.schedule;
 
 import eu.socialedge.hermes.repository.SpringJpaRepository;
-import eu.socialedge.hermes.schedule.Schedule;
+import eu.socialedge.hermes.domain.schedule.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/SpringJpaTimetableRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/SpringJpaTimetableRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.schedule;
 
 import eu.socialedge.hermes.repository.SpringJpaRepository;
-import eu.socialedge.hermes.schedule.Timetable;
+import eu.socialedge.hermes.domain.schedule.Timetable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;

--- a/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/TimetableRepository.java
+++ b/hermes-repository/src/main/java/eu/socialedge/hermes/repository/schedule/TimetableRepository.java
@@ -15,7 +15,7 @@
 package eu.socialedge.hermes.repository.schedule;
 
 import eu.socialedge.hermes.repository.Repository;
-import eu.socialedge.hermes.schedule.Timetable;
+import eu.socialedge.hermes.domain.schedule.Timetable;
 
 public interface TimetableRepository extends Repository<Integer, Timetable> {
 }


### PR DESCRIPTION
This commit fixes broken Line's mapping to Route entity; changes
Waypoint.order mapping to position column in db to prevent collision
with database's reserved keyword 'order'; moves all domain objects to
.domain package to improve separtion of code by layer
