### PR TITLE
Add PagingAndSortingRepository ext with eq/like filtering

### DIFF
--- a/backend/backend-schedule/src/main/java/eu/socialedge/hermes/backend/schedule/infrasturcture/config/ScheduleConfiguration.java
+++ b/backend/backend-schedule/src/main/java/eu/socialedge/hermes/backend/schedule/infrasturcture/config/ScheduleConfiguration.java
@@ -15,12 +15,14 @@
 
 package eu.socialedge.hermes.backend.schedule.infrasturcture.config;
 
+import eu.socialedge.hermes.backend.shared.infrastructure.persistence.MongoFilteringRepositoryFactoryBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
 @ComponentScan("eu.socialedge.hermes.backend.schedule.domain")
-@EnableMongoRepositories("eu.socialedge.hermes.backend.schedule.repository")
+@EnableMongoRepositories(value = "eu.socialedge.hermes.backend.schedule.repository",
+    repositoryFactoryBeanClass = MongoFilteringRepositoryFactoryBean.class)
 public class ScheduleConfiguration {
 }

--- a/backend/backend-schedule/src/main/java/eu/socialedge/hermes/backend/schedule/repository/ScheduleRepository.java
+++ b/backend/backend-schedule/src/main/java/eu/socialedge/hermes/backend/schedule/repository/ScheduleRepository.java
@@ -15,9 +15,9 @@
 package eu.socialedge.hermes.backend.schedule.repository;
 
 import eu.socialedge.hermes.backend.schedule.domain.Schedule;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ScheduleRepository extends PagingAndSortingRepository<Schedule, String> {
+public interface ScheduleRepository extends FilteringPagingAndSortingRepository<Schedule, String> {
 }

--- a/backend/backend-shared/build.gradle
+++ b/backend/backend-shared/build.gradle
@@ -14,17 +14,5 @@
  */
 
 dependencies {
-    compile project(":backend-shared")
-    compile libraries.commons.apacheLang3
-    compile libraries.commons.nvI18n
-    compile libraries.commons.beanValidation
-    compile libraries.commons.unitsMeasurement
-
     compile libraries.persistence.springDataMongoDb
-
-    compile libraries.geo.googleMapsApi
-
-    compileOnly libraries.application.springBootData
-
-    testCompile libraries.test.mockito
 }

--- a/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/domain/FilteringPagingAndSortingRepository.java
+++ b/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/domain/FilteringPagingAndSortingRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Hermes - The Municipal Transport Timetable System
+ * Copyright (c) 2016-2017 SocialEdge
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package eu.socialedge.hermes.backend.shared.domain;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import java.io.Serializable;
+
+/**
+ * Extension of {@link PagingAndSortingRepository} to provide additional methods to retrieve
+ * entities with filtering by exact and regexp field value.
+ *
+ * @param <T>  entity type
+ * @param <ID> entity's id type
+ */
+@NoRepositoryBean
+public interface FilteringPagingAndSortingRepository<T, ID extends Serializable>
+        extends PagingAndSortingRepository<T, ID> {
+
+    Iterable<T> findAll(String field, Object value);
+
+    Iterable<T> findAllLike(String field, String value);
+}

--- a/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringPagingAndSortingRepository.java
+++ b/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringPagingAndSortingRepository.java
@@ -1,0 +1,73 @@
+/*
+ * Hermes - The Municipal Transport Timetable System
+ * Copyright (c) 2016-2017 SocialEdge
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
+
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
+import lombok.val;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
+import org.springframework.data.mongodb.repository.support.SimpleMongoRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.Serializable;
+
+/**
+ * {@code MongoFilteringPagingAndSortingRepository} is an extension of the base
+ * mongo repository implementation for Mongo that provides an implementation for
+ * filtering methods of {@link FilteringPagingAndSortingRepository}.
+ *
+ * @param <T>  entity type
+ * @param <ID> entity's id type
+ */
+public class MongoFilteringPagingAndSortingRepository<T, ID extends Serializable>
+        extends SimpleMongoRepository<T, ID>
+        implements FilteringPagingAndSortingRepository<T, ID> {
+
+    private final MongoOperations mongoOperations;
+    private final Class<T> entityClass;
+
+    public MongoFilteringPagingAndSortingRepository(MongoEntityInformation<T, ID> metadata,
+                                                    MongoOperations mongoOperations) {
+        super(metadata, mongoOperations);
+
+        this.mongoOperations = mongoOperations;
+        this.entityClass = metadata.getJavaType();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Iterable<T> findAll(String field, Object value) {
+        val criterion = Criteria.where(field).is(value);
+
+        val query = new Query();
+        query.addCriteria(criterion);
+
+        return this.mongoOperations.find(query, entityClass);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Iterable<T> findAllLike(String field, String value) {
+        val criterion = Criteria.where(field).regex(value);
+
+        val query = new Query();
+        query.addCriteria(criterion);
+
+        return this.mongoOperations.find(query, entityClass);
+    }
+}

--- a/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringRepositoryFactoryBean.java
+++ b/backend/backend-shared/src/main/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringRepositoryFactoryBean.java
@@ -1,0 +1,104 @@
+/*
+ * Hermes - The Municipal Transport Timetable System
+ * Copyright (c) 2016-2017 SocialEdge
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
+
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
+import lombok.val;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
+import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.data.mongodb.repository.query.MongoEntityInformation;
+import org.springframework.data.mongodb.repository.support.MappingMongoEntityInformation;
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactory;
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactoryBean;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.RepositoryFactorySupport;
+import org.springframework.util.Assert;
+
+import java.io.Serializable;
+
+/**
+ * {@link org.springframework.beans.factory.FactoryBean} to create {@link MongoFilteringRepositoryFactory} or
+ * {@link MongoRepository} instances depending on repository's base interface.
+ * <p>
+ * This must be specified as {@code repositoryFactoryBeanClass} in {@link EnableMongoRepositories}
+ * in order to enable repositories of {@link FilteringPagingAndSortingRepository} type.
+ *
+ * @param <R> repository type
+ * @param <T> entity type
+ * @param <I> entity's id type
+ */
+public class MongoFilteringRepositoryFactoryBean<R extends MongoRepository<T, I>, T, I extends Serializable>
+        extends MongoRepositoryFactoryBean<R, T, I> {
+
+    public MongoFilteringRepositoryFactoryBean(Class<? extends R> repositoryInterface) {
+        super(repositoryInterface);
+    }
+
+    @Override
+    protected RepositoryFactorySupport getFactoryInstance(MongoOperations operations) {
+        return new MongoFilteringRepositoryFactory<T, I>(operations);
+    }
+
+    /**
+     * Factory to create {@link MongoFilteringPagingAndSortingRepository} or {@link MongoRepository} instances
+     * depending on repository's base interface
+     *
+     * @param <T> entity type
+     * @param <I> entity's id type
+     */
+    private static class MongoFilteringRepositoryFactory<T, I extends Serializable> extends MongoRepositoryFactory {
+
+        private final MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext;
+        private final MongoOperations mongoOperations;
+
+        public MongoFilteringRepositoryFactory(MongoOperations mongoOperations) {
+            super(mongoOperations);
+            this.mongoOperations = mongoOperations;
+            this.mappingContext = mongoOperations.getConverter().getMappingContext();
+        }
+
+        @Override
+        protected Class<?> getRepositoryBaseClass(RepositoryMetadata metadata) {
+            if (FilteringPagingAndSortingRepository.class.isAssignableFrom(metadata.getRepositoryInterface()))
+                return MongoFilteringPagingAndSortingRepository.class;
+
+            return super.getRepositoryBaseClass(metadata);
+        }
+
+        @Override
+        protected Object getTargetRepository(RepositoryInformation metadata) {
+            if (FilteringPagingAndSortingRepository.class.isAssignableFrom(metadata.getRepositoryInterface())) {
+                val entity = mappingContext.getPersistentEntity(metadata.getDomainType());
+                val entityInformation = entityInformationFor(entity, metadata.getIdType());
+
+                return new MongoFilteringPagingAndSortingRepository<>(entityInformation, mongoOperations);
+            }
+
+            return super.getTargetRepository(metadata);
+        }
+
+        @SuppressWarnings("unchecked")
+        private MongoEntityInformation<T, I> entityInformationFor(MongoPersistentEntity<?> entity, Class<?> idType) {
+            Assert.notNull(entity, "Entity must not be null!");
+            return new MappingMongoEntityInformation<>((MongoPersistentEntity<T>) entity, (Class<I>) idType);
+        }
+    }
+}

--- a/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringPagingAndSortingRepositoryTest.java
+++ b/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/MongoFilteringPagingAndSortingRepositoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hermes - The Municipal Transport Timetable System
+ * Copyright (c) 2016-2017 SocialEdge
+ * <p>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
+
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@DataMongoTest
+public class MongoFilteringPagingAndSortingRepositoryTest {
+
+    private static final List<TestDocument> BASE_DOCUMENTS = asList(
+        new TestDocument("assemble"),
+        new TestDocument("bootRepackage"),
+        new TestDocument("build"),
+        new TestDocument("buildDependents"),
+        new TestDocument("buildNeeded")
+    );
+
+    private static final List<TestDocument> BUILD_DOCUMENTS = BASE_DOCUMENTS.stream()
+        .filter(d -> d.getName().equals("build")).collect(Collectors.toList());
+
+    private static final List<TestDocument> BUILD_LIKE_DOCUMENTS = BASE_DOCUMENTS.stream()
+        .filter(d -> d.getName().contains("build")).collect(Collectors.toList());
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private TestFilteringPagingAndSortingRepository repository;
+
+    @Before
+    public void reloadTestDocumentCollection() {
+        mongoTemplate.remove(new Query(), TestDocument.class);
+        BASE_DOCUMENTS.forEach(mongoTemplate::insert);
+    }
+
+    @Test
+    public void findsAllDocumentsWithNameEqBuild() {
+        val buildDocuments = repository.findAll("name", "build");
+
+        assertEquals(BUILD_DOCUMENTS, buildDocuments);
+    }
+
+    @Test
+    public void findsAllDocumentsWithNameLikeBuild() {
+        val buildDocuments = repository.findAllLike("name", "build");
+
+        assertEquals(BUILD_LIKE_DOCUMENTS, buildDocuments);
+    }
+}

--- a/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestDocument.java
+++ b/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestDocument.java
@@ -13,8 +13,24 @@
  * GNU General Public License for more details.
  */
 
-dependencies {
-    compile libraries.persistence.springDataMongoDb
-    testCompile libraries.persistence.embeddedMongo
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+@Data
+@NoArgsConstructor
+public class TestDocument {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    public TestDocument(String name) {
+        this.name = name;
+    }
 }

--- a/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestFilteringPagingAndSortingRepository.java
+++ b/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestFilteringPagingAndSortingRepository.java
@@ -13,8 +13,10 @@
  * GNU General Public License for more details.
  */
 
-dependencies {
-    compile libraries.persistence.springDataMongoDb
-    testCompile libraries.persistence.embeddedMongo
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
 
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
+
+public interface TestFilteringPagingAndSortingRepository
+        extends FilteringPagingAndSortingRepository<TestDocument, String> {
 }

--- a/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestSpringBootConfiguration.java
+++ b/backend/backend-shared/src/test/java/eu/socialedge/hermes/backend/shared/infrastructure/persistence/TestSpringBootConfiguration.java
@@ -12,9 +12,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+package eu.socialedge.hermes.backend.shared.infrastructure.persistence;
 
-dependencies {
-    compile libraries.persistence.springDataMongoDb
-    testCompile libraries.persistence.embeddedMongo
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@EnableMongoRepositories(repositoryFactoryBeanClass = MongoFilteringRepositoryFactoryBean.class)
+public class TestSpringBootConfiguration {
 
 }

--- a/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/infra/StationRepository.java
+++ b/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/infra/StationRepository.java
@@ -14,14 +14,14 @@
  */
 package eu.socialedge.hermes.backend.transit.domain.infra;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface StationRepository extends PagingAndSortingRepository<Station, String> {
+public interface StationRepository extends FilteringPagingAndSortingRepository<Station, String> {
 
     List<Station> findByNameContainingIgnoreCase(@Param("name") String name);
 }

--- a/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/provider/AgencyRepository.java
+++ b/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/provider/AgencyRepository.java
@@ -14,9 +14,9 @@
  */
 package eu.socialedge.hermes.backend.transit.domain.provider;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AgencyRepository extends PagingAndSortingRepository<Agency, String> {
+public interface AgencyRepository extends FilteringPagingAndSortingRepository<Agency, String> {
 }

--- a/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/service/LineRepository.java
+++ b/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/domain/service/LineRepository.java
@@ -14,9 +14,9 @@
  */
 package eu.socialedge.hermes.backend.transit.domain.service;
 
-import org.springframework.data.repository.PagingAndSortingRepository;
+import eu.socialedge.hermes.backend.shared.domain.FilteringPagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LineRepository extends PagingAndSortingRepository<Line, String> {
+public interface LineRepository extends FilteringPagingAndSortingRepository<Line, String> {
 }

--- a/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/infrastructure/config/TransitConfiguration.java
+++ b/backend/backend-transit/src/main/java/eu/socialedge/hermes/backend/transit/infrastructure/config/TransitConfiguration.java
@@ -15,6 +15,7 @@
 
 package eu.socialedge.hermes.backend.transit.infrastructure.config;
 
+import eu.socialedge.hermes.backend.shared.infrastructure.persistence.MongoFilteringRepositoryFactoryBean;
 import eu.socialedge.hermes.backend.transit.domain.service.DistanceAwareSegmentFactory;
 import eu.socialedge.hermes.backend.transit.domain.geo.gmaps.GMapsTravelDistanceMeter;
 import eu.socialedge.hermes.backend.transit.domain.geo.TravelDistanceMeter;
@@ -39,7 +40,8 @@ import static java.util.Arrays.asList;
 @ComponentScan({
     "eu.socialedge.hermes.backend.transit.domain",
     "eu.socialedge.hermes.backend.transit.infrastructure"})
-@EnableMongoRepositories("eu.socialedge.hermes.backend.transit.domain")
+@EnableMongoRepositories(value = "eu.socialedge.hermes.backend.transit.domain",
+    repositoryFactoryBeanClass = MongoFilteringRepositoryFactoryBean.class)
 public class TransitConfiguration {
 
     @Autowired

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,6 +60,7 @@ subprojects {
         compileOnly libraries.gen.lombok
 
         testCompile libraries.test.junit
+        testCompile libraries.test.spring
         testCompileOnly libraries.gen.lombok
         integrationTestCompile libraries.gen.lombok
     }

--- a/backend/dependencies.gradle
+++ b/backend/dependencies.gradle
@@ -85,6 +85,10 @@ ext {
                 "junit:junit:${versions.test.junit}",
                 "org.assertj:assertj-core:${versions.test.assertj}"
             ],
+            spring: [
+                "org.springframework.boot:spring-boot-starter-jdbc:${versions.application.springBoot}",
+                "org.springframework.boot:spring-boot-starter-test:${versions.application.springBoot}"
+            ],
             mockito: "org.mockito:mockito-core:${versions.test.mockito}"
         ]
     ]

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -17,4 +17,5 @@ rootProject.name = 'hermes'
 include 'backend-transit'
 include 'backend-schedule'
 include 'backend-application'
+include 'backend-shared'
 


### PR DESCRIPTION
Adds `findAll(String field, Object value)` for $eq filtering and `findAllLike(String filed, String value)` for $regexp filtering to existing domain repositories.

I would suggest to add corresponding `?filter=field,value` and `?filterLike=field,value` query params to the API.